### PR TITLE
Added parachute support for transport helicopters

### DIFF
--- a/SpecialOperations2.Altis/Description.ext
+++ b/SpecialOperations2.Altis/Description.ext
@@ -1,7 +1,7 @@
 #include                    "sos\arsenal\SOS_VirtualArsenal.hpp"
 #include                    "sos\vehicle\SOS_VehicleSpawn.hpp"
 #include                    "sos\vehicle\SOS_VehicleProtection.hpp"
-#include					"sos\utils\SOS_VehicleType.hpp"
+#include					"sos\utils\SOS_VehicleTypes.hpp"
 
 onLoadName                  = "Special Operations 2";
 onLoadMission               = "New Tactical Gaming!";

--- a/SpecialOperations2.Altis/Description.ext
+++ b/SpecialOperations2.Altis/Description.ext
@@ -1,6 +1,7 @@
 #include                    "sos\arsenal\SOS_VirtualArsenal.hpp"
 #include                    "sos\vehicle\SOS_VehicleSpawn.hpp"
 #include                    "sos\vehicle\SOS_VehicleProtection.hpp"
+#include					"sos\utils\SOS_VehicleType.hpp"
 
 onLoadName                  = "Special Operations 2";
 onLoadMission               = "New Tactical Gaming!";

--- a/SpecialOperations2.Altis/sos/CfgFunctions.hpp
+++ b/SpecialOperations2.Altis/sos/CfgFunctions.hpp
@@ -1,5 +1,10 @@
 class SOS_Functions {
     tag = "SOS";
+	
+	class Actions {
+		file = "sos\actions\functions";
+		class parachute {};
+	};
 
     class Arsenal {
         file = "sos\arsenal\functions";

--- a/SpecialOperations2.Altis/sos/actions/functions/fn_parachute.sqf
+++ b/SpecialOperations2.Altis/sos/actions/functions/fn_parachute.sqf
@@ -1,0 +1,32 @@
+/*
+ * Author: EnquiringStone [S.O.S. Captain]
+ * Gives the given unit a parachute at a certain height
+ *
+ * Arguments:
+ * 0: vehicle <OBJECT>
+ * 1: unit <OBJECT>
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Example:
+ * [_vehicle, _unit] call SOS_fnc_parachute;
+ *
+ */
+
+private ["_vehicle", "_unit", "_height", "_direction", "_parachute"];
+ 
+_vehicle = _this select 0;
+_unit = _this select 1;
+_height = 100;
+_direction = direction _vehicle;
+ 
+moveOut _unit;
+ 
+waitUntil {((getPos _unit) select 2) <= _height};
+if (vehicle _unit != _unit) exitWith {};
+_parachute = createVehicle ["Steerable_Parachute_F", position _unit, [], ((_direction)- 5 + (random 10)), 'FLY'];
+_parachute setPos (getPos _unit);
+
+_unit assignAsDriver _parachute;
+_unit moveInDriver _parachute;

--- a/SpecialOperations2.Altis/sos/utils/SOS_VehicleTypes.hpp
+++ b/SpecialOperations2.Altis/sos/utils/SOS_VehicleTypes.hpp
@@ -1,0 +1,149 @@
+class SOS_VehicleTypes {
+	class TransportHelicopters {
+		vehicles[] = {
+			"B_Heli_Light_01_F",
+			"B_Heli_Transport_01_F",
+			"B_Heli_Transport_01_camo_F",
+			"B_Heli_Transport_03_F",
+			"B_Heli_Transport_03_unarmed_F",
+			"I_Heli_light_03_F",
+			"I_Heli_light_03_unarmed_F",
+			"I_Heli_Transport_02_F",
+			"O_Heli_Attack_02_F",
+			"O_Heli_Attack_02_black_F",
+			"O_Heli_Light_02_F",
+			"O_Heli_Light_02_unarmed_F",
+			"O_Heli_Light_02_v2_F",
+			"O_Heli_Transport_04_bench_F",
+			"O_Heli_Transport_04_covered_F"
+		};
+	};
+	
+	class TransportVehicles {
+		vehicles[] = {
+			"B_G_Offroad_01_F",
+			"B_G_Van_01_transport_F",
+			"B_MRAP_01_F",
+			"B_MRAP_01_gmg_F",
+			"B_MRAP_01_hmg_F",
+			"B_Truck_01_covered_F",
+			"B_Truck_01_transport_F",
+			"B_Quadbike_01_F",
+			"I_MRAP_03_F",
+			"I_MRAP_03_gmg_F",
+			"I_MRAP_03_hmg_F",
+			"I_Truck_02_covered_F",
+			"I_Truck_02_transport_F",
+			"O_MRAP_02_F",
+			"O_MRAP_02_hmg_F",
+			"O_MRAP_02_gmg_F",
+			"O_Truck_02_covered_F",
+			"O_Truck_02_transport_F"
+		};
+	};
+	
+	class ArmedHelicopters {
+		vehicles[] = {
+			"B_Heli_Attack_01_F",
+			"B_Heli_Light_01_armed_F",
+			"B_Heli_Transport_01_F",
+			"B_Heli_Transport_01_camo_F",
+			"B_Heli_Transport_03_F",
+			"I_Heli_light_03_F",
+			"O_Heli_Attack_02_F",
+			"O_Heli_Attack_02_black_F",
+			"O_Heli_Light_02_F"
+		};
+	};
+	
+	class ArmedVehicles {
+		vehicles[] = {
+			"B_G_Offroad_01_armed_F",
+			"B_MRAP_01_gmg_F",
+			"B_MRAP_01_hmg_F",
+			"I_MRAP_03_gmg_F",
+			"I_MRAP_03_hmg_F",
+			"O_MRAP_02_gmg_F",
+			"O_MRAP_02_hmg_F"
+		};
+	};
+	
+	class LogisticsHelicopters {
+		vehicles[] = {
+			"B_Heli_Transport_01_F",
+			"B_Heli_Transport_01_camo_F",
+			"O_Heli_Transport_04_ammo_F",
+			"O_Heli_Transport_04_box_F",
+			"O_Heli_Transport_04_fuel_F",
+			"O_Heli_Transport_04_medevac_F",
+			"O_Heli_Transport_04_repair_F"
+		};
+	};
+	
+	class LogisticsVehicles {
+		vehicles[] = {
+			"B_G_Offroad_01_repair_F",
+			"B_G_Van_01_fuel_F",
+			"B_Truck_01_ammo_F",
+			"B_Truck_01_box_F",
+			"B_Truck_01_fuel_F",
+			"B_Truck_01_medical_F",
+			"B_Truck_01_Repair_F",
+			"I_Truck_02_ammo_F",
+			"I_Truck_02_box_F",
+			"I_Truck_02_fuel_F",
+			"I_Truck_02_medical_F",
+			"O_Truck_02_Ammo_F",
+			"O_Truck_02_box_F",
+			"O_Truck_02_fuel_F",
+			"O_Truck_02_medical_F",
+			"O_Truck_03_ammo_F",
+			"O_Truck_03_fuel_F",
+			"O_Truck_03_medical_F",
+			"O_Truck_03_repair_F"
+		};
+	};
+	
+	class Medical {
+		vehicles[] = {
+			"B_Truck_01_medical_F",
+			"I_Truck_02_medical_F",
+			"O_Heli_Transport_04_medevac_F",
+			"O_Truck_02_medical_F",
+			"O_Truck_03_medical_F"
+		};
+	};
+	
+	class Repair {
+		vehicles[] = {
+			"B_G_Offroad_01_repair_F",
+			"B_Truck_01_Repair_F",
+			"I_Truck_02_box_F",
+			"O_Heli_Transport_04_repair_F",
+			"O_Truck_02_box_F",
+			"O_Truck_03_repair_F"
+		};
+	};
+	
+	class Fuel {
+		vehicles[] = {
+			"B_G_Van_01_fuel_F",
+			"B_Truck_01_fuel_F",
+			"I_Truck_02_fuel_F",
+			"O_Heli_Transport_04_fuel_F",
+			"O_Truck_02_fuel_F",
+			"O_Truck_03_fuel_F"
+		};
+	};
+	
+	class Ammo {
+		vehicles[] = {
+			"B_Truck_01_ammo_F",
+			"B_Truck_01_box_F",
+			"I_Truck_02_ammo_F",
+			"O_Heli_Transport_04_box_F",
+			"O_Truck_02_Ammo_F",
+			"O_Truck_03_ammo_F"
+		};
+	};
+};

--- a/SpecialOperations2.Altis/sos/utils/SOS_VehicleTypes.hpp
+++ b/SpecialOperations2.Altis/sos/utils/SOS_VehicleTypes.hpp
@@ -17,6 +17,27 @@ class SOS_VehicleTypes {
 			"O_Heli_Transport_04_bench_F",
 			"O_Heli_Transport_04_covered_F"
 		};
+		blufor[] = {
+			"B_Heli_Light_01_F",
+			"B_Heli_Transport_01_F",
+			"B_Heli_Transport_01_camo_F",
+			"B_Heli_Transport_03_F",
+			"B_Heli_Transport_03_unarmed_F"
+		};
+		independent[] = {
+			"I_Heli_light_03_F",
+			"I_Heli_light_03_unarmed_F",
+			"I_Heli_Transport_02_F"
+		};
+		opfor[] = {
+			"O_Heli_Attack_02_F",
+			"O_Heli_Attack_02_black_F",
+			"O_Heli_Light_02_F",
+			"O_Heli_Light_02_unarmed_F",
+			"O_Heli_Light_02_v2_F",
+			"O_Heli_Transport_04_bench_F",
+			"O_Heli_Transport_04_covered_F"
+		};
 	};
 	
 	class TransportVehicles {
@@ -40,6 +61,30 @@ class SOS_VehicleTypes {
 			"O_Truck_02_covered_F",
 			"O_Truck_02_transport_F"
 		};
+		blufor[] = {
+			"B_G_Offroad_01_F",
+			"B_G_Van_01_transport_F",
+			"B_MRAP_01_F",
+			"B_MRAP_01_gmg_F",
+			"B_MRAP_01_hmg_F",
+			"B_Truck_01_covered_F",
+			"B_Truck_01_transport_F",
+			"B_Quadbike_01_F"
+		};
+		independent[] = {
+			"I_MRAP_03_F",
+			"I_MRAP_03_gmg_F",
+			"I_MRAP_03_hmg_F",
+			"I_Truck_02_covered_F",
+			"I_Truck_02_transport_F"
+		};
+		opfor[] = {
+			"O_MRAP_02_F",
+			"O_MRAP_02_hmg_F",
+			"O_MRAP_02_gmg_F",
+			"O_Truck_02_covered_F",
+			"O_Truck_02_transport_F"
+		};
 	};
 	
 	class ArmedHelicopters {
@@ -50,6 +95,21 @@ class SOS_VehicleTypes {
 			"B_Heli_Transport_01_camo_F",
 			"B_Heli_Transport_03_F",
 			"I_Heli_light_03_F",
+			"O_Heli_Attack_02_F",
+			"O_Heli_Attack_02_black_F",
+			"O_Heli_Light_02_F"
+		};
+		blufor[] = {
+			"B_Heli_Attack_01_F",
+			"B_Heli_Light_01_armed_F",
+			"B_Heli_Transport_01_F",
+			"B_Heli_Transport_01_camo_F",
+			"B_Heli_Transport_03_F"
+		};
+		independent[] = {
+			"I_Heli_light_03_F"
+		};
+		opfor[] = {
 			"O_Heli_Attack_02_F",
 			"O_Heli_Attack_02_black_F",
 			"O_Heli_Light_02_F"
@@ -66,12 +126,39 @@ class SOS_VehicleTypes {
 			"O_MRAP_02_gmg_F",
 			"O_MRAP_02_hmg_F"
 		};
+		blufor[] = {
+			"B_G_Offroad_01_armed_F",
+			"B_MRAP_01_gmg_F",
+			"B_MRAP_01_hmg_F"
+		};
+		independent[] = {
+			"I_MRAP_03_gmg_F",
+			"I_MRAP_03_hmg_F"
+		};
+		opfor[] = {
+			"O_MRAP_02_gmg_F",
+			"O_MRAP_02_hmg_F"
+		};
 	};
 	
 	class LogisticsHelicopters {
 		vehicles[] = {
 			"B_Heli_Transport_01_F",
 			"B_Heli_Transport_01_camo_F",
+			"O_Heli_Transport_04_ammo_F",
+			"O_Heli_Transport_04_box_F",
+			"O_Heli_Transport_04_fuel_F",
+			"O_Heli_Transport_04_medevac_F",
+			"O_Heli_Transport_04_repair_F"
+		};
+		blufor[] = {
+			"B_Heli_Transport_01_F",
+			"B_Heli_Transport_01_camo_F"
+		};
+		independent[] = {
+			
+		};
+		opfor[] = {
 			"O_Heli_Transport_04_ammo_F",
 			"O_Heli_Transport_04_box_F",
 			"O_Heli_Transport_04_fuel_F",
@@ -102,12 +189,48 @@ class SOS_VehicleTypes {
 			"O_Truck_03_medical_F",
 			"O_Truck_03_repair_F"
 		};
+		blufor[] = {
+			"B_G_Offroad_01_repair_F",
+			"B_G_Van_01_fuel_F",
+			"B_Truck_01_ammo_F",
+			"B_Truck_01_box_F",
+			"B_Truck_01_fuel_F",
+			"B_Truck_01_medical_F",
+			"B_Truck_01_Repair_F"
+		};
+		independent[] = {
+			"I_Truck_02_ammo_F",
+			"I_Truck_02_box_F",
+			"I_Truck_02_fuel_F",
+			"I_Truck_02_medical_F"
+		};
+		opfor[] = {
+			"O_Truck_02_Ammo_F",
+			"O_Truck_02_box_F",
+			"O_Truck_02_fuel_F",
+			"O_Truck_02_medical_F",
+			"O_Truck_03_ammo_F",
+			"O_Truck_03_fuel_F",
+			"O_Truck_03_medical_F",
+			"O_Truck_03_repair_F"
+		};
 	};
 	
 	class Medical {
 		vehicles[] = {
 			"B_Truck_01_medical_F",
 			"I_Truck_02_medical_F",
+			"O_Heli_Transport_04_medevac_F",
+			"O_Truck_02_medical_F",
+			"O_Truck_03_medical_F"
+		};
+		blufor[] = {
+			"B_Truck_01_medical_F"
+		};
+		independent[] = {
+			"I_Truck_02_medical_F"
+		};
+		opfor[] = {
 			"O_Heli_Transport_04_medevac_F",
 			"O_Truck_02_medical_F",
 			"O_Truck_03_medical_F"
@@ -123,6 +246,18 @@ class SOS_VehicleTypes {
 			"O_Truck_02_box_F",
 			"O_Truck_03_repair_F"
 		};
+		blufor[] = {
+			"B_G_Offroad_01_repair_F",
+			"B_Truck_01_Repair_F"
+		};
+		independent[] = {
+			"I_Truck_02_box_F"
+		};
+		opfor[] = {
+			"O_Heli_Transport_04_repair_F",
+			"O_Truck_02_box_F",
+			"O_Truck_03_repair_F"
+		};
 	};
 	
 	class Fuel {
@@ -134,6 +269,18 @@ class SOS_VehicleTypes {
 			"O_Truck_02_fuel_F",
 			"O_Truck_03_fuel_F"
 		};
+		blufor[] = {
+			"B_G_Van_01_fuel_F",
+			"B_Truck_01_fuel_F"
+		};
+		independent[] = {
+			"I_Truck_02_fuel_F"
+		};
+		opfor[] = {
+			"O_Heli_Transport_04_fuel_F",
+			"O_Truck_02_fuel_F",
+			"O_Truck_03_fuel_F"
+		};
 	};
 	
 	class Ammo {
@@ -141,6 +288,18 @@ class SOS_VehicleTypes {
 			"B_Truck_01_ammo_F",
 			"B_Truck_01_box_F",
 			"I_Truck_02_ammo_F",
+			"O_Heli_Transport_04_box_F",
+			"O_Truck_02_Ammo_F",
+			"O_Truck_03_ammo_F"
+		};
+		blufor[] = {
+			"B_Truck_01_ammo_F",
+			"B_Truck_01_box_F"
+		};
+		independent[] = {
+			"I_Truck_02_ammo_F"
+		};
+		opfor[] = {
 			"O_Heli_Transport_04_box_F",
 			"O_Truck_02_Ammo_F",
 			"O_Truck_03_ammo_F"

--- a/SpecialOperations2.Altis/sos/vehicle/functions/fn_initVehicle.sqf
+++ b/SpecialOperations2.Altis/sos/vehicle/functions/fn_initVehicle.sqf
@@ -47,3 +47,11 @@ if !([] call SOS_fnc_isMember) then {
 		} forEach SOS_MISSION_SAFE_ZONES;
 	}];
 };
+
+if((typeOf _vehicle) in (getArray(missionConfigFile >> format ["SOS_VehicleTypes"] >> "TransportHelicopters" >> "vehicles"))) then {
+	_vehicle addAction ["Parachute", {
+		_heli = _this select 0;
+		_unit = _this select 1;
+		[_heli, _unit] call SOS_fnc_parachute;
+	}, nil, 5, false, true, "", "(((getPos _target) select 2) > 150) && (player in (assignedCargo _target))"];
+};


### PR DESCRIPTION
Has a helper class to easily identify helicopters and vehicles and its roles.
This helper class is divided into 4 section: vehicles (all vehicles/helicopters for all sides), blufor, independent and opfor.
Added an action to every transport helicopter that spawns.
Needs to be tested on server (works locally). I have a feeling that I need to use BIS_fnc_MP when creating the parachute.
The backpack stays on you the entire time. So this will not remove your backpack.
The indentations are not representative of the real world. (they are all aligned)
